### PR TITLE
accept OPTION method

### DIFF
--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -3,7 +3,7 @@ module Railsroot
     config.middleware.insert_before 0, "Rack::Cors" do
       allow do
         origins '*'
-        resource '*', headers: :any, methods: [:get, :post, :options, :put]
+        resource '*', headers: :any, methods: [:get, :post, :options, :put, :delete]
       end
     end
   end


### PR DESCRIPTION
This PR would fix this kind of exceptions: 

```
Started OPTIONS "/api/v1/users/sign_out" for 192.168.1.139 at 2016-10-17 14:35:27 -0300

ActionController::RoutingError (No route matches [OPTIONS] "/api/v1/users/sign_out"):
  actionpack (4.2.6) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.6) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `block in call'
```
